### PR TITLE
Apply some Rust standards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 
 [dependencies]
 num-traits = "0.2.14"
+
+[dev-dependencies]
 ndarray = "0.15.4"
 rand = "0.8.4"

--- a/src/TSP_test.rs
+++ b/src/TSP_test.rs
@@ -99,16 +99,16 @@ impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap {
         se.first_mut()[self.i] = aux;
 
         // reverse move
-        let mv = Box::new(MoveSwap {
+
+        Box::new(MoveSwap {
             pTSP: self.pTSP.clone(),
             i: self.j,
             j: self.i,
-        });
-        return mv;
+        })
     }
 
     fn canBeApplied(&self, _se: &ESolutionTSP) -> bool {
-        return (i32::abs((self.i - self.j) as i32) >= 2) && (self.i >= 1) && (self.j >= 1);
+        (i32::abs((self.i - self.j) as i32) >= 2) && (self.i >= 1) && (self.j >= 1)
     }
     //
 
@@ -140,7 +140,7 @@ impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap {
         let newObjVal = se.second().evaluation() + diff;
         se.second_mut().setObjFunction(newObjVal);
         //se.second().setObjFunction(se.second().evaluation() + diff);
-        return rev;
+        rev
     }
     //
 
@@ -164,15 +164,14 @@ impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap {
             + pTSP.dist[[s[j - 1] as usize, s[i] as usize]]
             + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
         //
-        return Some(Evaluation {
+        Some(Evaluation {
             objVal: diff,
             outdated: false,
-        });
+        })
     }
 
     fn toString(&self) -> String {
-        let str = format!("MoveSwap i={} j={}", self.i, self.j);
-        return str;
+        format!("MoveSwap i={} j={}", self.i, self.j)
     }
 }
 
@@ -187,16 +186,13 @@ impl fmt::Display for MoveSwap {
 // (not necessary, but part of OptFrame Quickstart tutorial)
 // ------------------------
 
+#[allow(dead_code)]
 fn makeMoveSwap(
     pTSP: Rc<TSPProblemContext>,
     i: usize,
     j: usize,
 ) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
-    return Box::new(MoveSwap {
-        pTSP: pTSP.clone(),
-        i,
-        j,
-    });
+    Box::new(MoveSwap { pTSP, i, j })
 }
 
 // ------------------------
@@ -221,7 +217,7 @@ FNS<ESolutionTSP> nsswap{
    fRandomSwap
 };
 */
-
+#[test]
 fn main() {
     println!("Welcome to OptFrame Project (Rust version) - github.com/optframe");
 
@@ -256,17 +252,17 @@ fn main() {
             let mut i: usize = 0;
             while i < _n {
                 v[i] = i as i32;
-                i = i + 1;
+                i += 1;
             }
             v.shuffle(&mut thread_rng());
-            return v;
+            v
         },
     };
 
     let sol = fc.generateSolution();
 
-    print!("solution: {:?}\n", sol);
-    print!("distances:\n {:?}\n", pTSP.dist);
+    println!("solution: {:?}", sol);
+    println!("distances:\n {:?}", pTSP.dist);
 
     let fev = FEvaluator {
         fEvaluate: |s: &Vec<i32>| -> Evaluation {
@@ -274,13 +270,13 @@ fn main() {
             let mut i: usize = 0;
             while i < (pTSP.n - 1) {
                 f += pTSP.dist[[s[i] as usize, s[i + 1] as usize]] as f64;
-                i = i + 1;
+                i += 1;
             }
             f += pTSP.dist[[s[pTSP.n - 1] as usize, s[0] as usize]] as f64;
-            return Evaluation {
+            Evaluation {
                 objVal: f,
                 outdated: false,
-            };
+            }
         },
         phantomXS: PhantomData,
         phantomXEv: PhantomData,
@@ -288,7 +284,7 @@ fn main() {
 
     let ev = fev.evaluate(&sol);
 
-    print!("evaluation: {:?}\n", ev.evaluation());
+    println!("evaluation: {:?}", ev.evaluation());
 
     // ======================
     // tests with moves
@@ -302,7 +298,7 @@ fn main() {
         j: 1,
     };
 
-    print!("mv1: {}\n", mv1);
+    println!("mv1: {}", mv1);
 
     let mut esol = ESolutionTSP {
         first_value: sol,
@@ -311,7 +307,7 @@ fn main() {
 
     let mv2 = mv1.apply(&mut esol);
 
-    print!("mv2: {}\n", mv2.toString());
+    println!("mv2: {}", mv2.toString());
 
     let _mv3 = mv2.apply(&mut esol);
 

--- a/src/TSP_test.rs
+++ b/src/TSP_test.rs
@@ -1,34 +1,16 @@
-#![allow(non_snake_case)]
+use std::{fmt, marker::PhantomData, rc::Rc};
 
-mod optfcore;
-mod optframe;
+use ndarray::Array2;
+use rand::{prelude::SliceRandom, thread_rng};
 
-use optfcore::fconstructive::FConstructive;
-use optfcore::fevaluator::FEvaluator;
-use optframe::core::base_concepts::{XESolution, XSolution};
-use optframe::core::evaluation::Evaluation;
-
-use crate::optframe::core::constructive::Constructive;
-use crate::optframe::core::evaluator::Evaluator;
-use crate::optframe::core::mod_move::Move;
-
-use crate::optframe::core::base_concepts::XEvaluation;
-
-// reference counted (for Problem Context)
-use std::rc::Rc;
-
-// formatter (operator<< on Display)
-use std::fmt;
-
-//use rand::Rng;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
-
-use std::marker::PhantomData;
-
-// ------------------------
-// begin real code
-// ------------------------
+use crate::{
+    core::{
+        evaluation::{XESolution, XEvaluation, XSolution},
+        mod_move::Move,
+        Constructive, Evaluation, Evaluator,
+    },
+    FConstructive, FEvaluator,
+};
 
 pub struct ESolutionTSP {
     pub first_value: Vec<i32>,
@@ -55,8 +37,6 @@ impl XESolution<Vec<i32>, Evaluation> for ESolutionTSP {
 }
 
 // ------------------------
-
-use ndarray::Array2;
 
 // TSP problem context and data reads
 pub struct TSPProblemContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![doc = include_str!("../README.md")]
 
 mod optfcore;
 mod optframe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+#![allow(non_snake_case)]
+
+mod optfcore;
+mod optframe;
+
+pub use optfcore::fconstructive::FConstructive;
+pub use optfcore::fevaluator::FEvaluator;
+
+pub use optframe::core;
+pub use optframe::heuristics;
+
+#[cfg(test)]
+mod TSP_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ mod optframe;
 pub use optfcore::fconstructive::FConstructive;
 pub use optfcore::fevaluator::FEvaluator;
 
-pub use optframe::core;
-pub use optframe::heuristics;
+pub use crate::optframe::core;
+pub use crate::optframe::heuristics;
 
 #[cfg(test)]
 mod TSP_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(non_snake_case)]
 #![doc = include_str!("../README.md")]
 
 mod optfcore;
@@ -11,4 +10,4 @@ pub use crate::optframe::core;
 pub use crate::optframe::heuristics;
 
 #[cfg(test)]
-mod TSP_test;
+mod tsp_test;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,16 @@
 #![allow(non_snake_case)]
 
-mod optframe;
 mod optfcore;
+mod optframe;
 
-use optframe::core::base_concepts::{XSolution, XESolution};
-use optframe::core::evaluation::Evaluation;
 use optfcore::fconstructive::FConstructive;
 use optfcore::fevaluator::FEvaluator;
+use optframe::core::base_concepts::{XESolution, XSolution};
+use optframe::core::evaluation::Evaluation;
 
 use crate::optframe::core::constructive::Constructive;
 use crate::optframe::core::evaluator::Evaluator;
 use crate::optframe::core::mod_move::Move;
-
 
 use crate::optframe::core::base_concepts::XEvaluation;
 
@@ -21,13 +20,11 @@ use std::rc::Rc;
 // formatter (operator<< on Display)
 use std::fmt;
 
-
 //use rand::Rng;
-use rand::{thread_rng};
 use rand::seq::SliceRandom;
+use rand::thread_rng;
 
 use std::marker::PhantomData;
-
 
 // ------------------------
 // begin real code
@@ -35,29 +32,24 @@ use std::marker::PhantomData;
 
 pub struct ESolutionTSP {
     pub first_value: Vec<i32>,
-    pub second_value: Evaluation
+    pub second_value: Evaluation,
 }
 
-impl XSolution for Vec<i32>
-{
+impl XSolution for Vec<i32> {
     // nothing to do! must have something to do with Copy trait!!!
 }
 
 impl XESolution<Vec<i32>, Evaluation> for ESolutionTSP {
-    fn first(&self) -> &Vec<i32>
-    {
+    fn first(&self) -> &Vec<i32> {
         &self.first_value
     }
-    fn second(&self) -> &Evaluation
-    {
+    fn second(&self) -> &Evaluation {
         &self.second_value
     }
-    fn first_mut(&mut self) -> &mut Vec<i32>
-    {
+    fn first_mut(&mut self) -> &mut Vec<i32> {
         &mut self.first_value
     }
-    fn second_mut(&mut self) -> &mut Evaluation
-    {
+    fn second_mut(&mut self) -> &mut Evaluation {
         &mut self.second_value
     }
 }
@@ -67,39 +59,38 @@ impl XESolution<Vec<i32>, Evaluation> for ESolutionTSP {
 use ndarray::Array2;
 
 // TSP problem context and data reads
-pub struct  TSPProblemContext
-{
-    pub n : usize,
-    pub dist : Array2<i32>,
+pub struct TSPProblemContext {
+    pub n: usize,
+    pub dist: Array2<i32>,
     /*
-public:
-   int n;            // number of clients
-   Matrix<int> dist; // distance matrix (Euclidean)
-   // load data from Scanner
-   void load(Scanner& scanner)
-   {
-      n = *scanner.nextInt();   // reads number of clients
-      dist = Matrix<int>(n, n); // initializes n x n matrix
-      //
-      vector<double> xvalues(n);
-      vector<double> yvalues(n);
-      //
-      for (int i = 0; i < n; i++) {
-         scanner.next();
-         xvalues[i] = *scanner.nextDouble(); // reads x
-         yvalues[i] = *scanner.nextDouble(); // reads y
-      }
-      // calculate distance values, for every client pair (i,j)
-      for (int i = 0; i < n; i++)
-         for (int j = 0; j < n; j++)
-            dist(i, j) = ::round(distance(xvalues.at(i), yvalues.at(i), xvalues.at(j), yvalues.at(j)));
-   }
-   // euclidean distance (double as return)
-   double distance(double x1, double y1, double x2, double y2)
-   {
-      return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
-   }
-   */
+    public:
+       int n;            // number of clients
+       Matrix<int> dist; // distance matrix (Euclidean)
+       // load data from Scanner
+       void load(Scanner& scanner)
+       {
+          n = *scanner.nextInt();   // reads number of clients
+          dist = Matrix<int>(n, n); // initializes n x n matrix
+          //
+          vector<double> xvalues(n);
+          vector<double> yvalues(n);
+          //
+          for (int i = 0; i < n; i++) {
+             scanner.next();
+             xvalues[i] = *scanner.nextDouble(); // reads x
+             yvalues[i] = *scanner.nextDouble(); // reads y
+          }
+          // calculate distance values, for every client pair (i,j)
+          for (int i = 0; i < n; i++)
+             for (int j = 0; j < n; j++)
+                dist(i, j) = ::round(distance(xvalues.at(i), yvalues.at(i), xvalues.at(j), yvalues.at(j)));
+       }
+       // euclidean distance (double as return)
+       double distance(double x1, double y1, double x2, double y2)
+       {
+          return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+       }
+       */
 }
 
 impl fmt::Display for TSPProblemContext {
@@ -110,56 +101,59 @@ impl fmt::Display for TSPProblemContext {
 
 // ------------------------
 
-pub struct MoveSwap
-{
-    pub pTSP : Rc<TSPProblemContext>,
-    pub i : usize,
-    pub j : usize
+pub struct MoveSwap {
+    pub pTSP: Rc<TSPProblemContext>,
+    pub i: usize,
+    pub j: usize,
 }
 
 // ------------------------
 
-impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap
-{
-    fn apply(&self, se: &mut ESolutionTSP) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>>
-    {
+impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap {
+    fn apply(&self, se: &mut ESolutionTSP) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
         println!("apply from MoveSwap {} {}", self.i, self.j);
         //println!("problem is:\n {}", self.pTSP);
 
-        let aux : i32 = se.first()[self.j];
+        let aux: i32 = se.first()[self.j];
         se.first_mut()[self.j] = se.first_mut()[self.i];
         se.first_mut()[self.i] = aux;
 
         // reverse move
-        let mv = Box::new(MoveSwap{pTSP: self.pTSP.clone(), i:self.j, j:self.i});
-        return mv
+        let mv = Box::new(MoveSwap {
+            pTSP: self.pTSP.clone(),
+            i: self.j,
+            j: self.i,
+        });
+        return mv;
     }
 
-    fn canBeApplied(&self, _se: &ESolutionTSP) -> bool
-    {
+    fn canBeApplied(&self, _se: &ESolutionTSP) -> bool {
         return (i32::abs((self.i - self.j) as i32) >= 2) && (self.i >= 1) && (self.j >= 1);
     }
     //
 
-    fn applyUpdate(&self, se: &mut ESolutionTSP) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>>
-    {
+    fn applyUpdate(
+        &self,
+        se: &mut ESolutionTSP,
+    ) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
         // input cannot be outdated
         assert!(!se.second().isOutdated());
         let s = &mut se.first();
         //
-        let i : usize = self.i;
-        let j : usize = self.j;
+        let i: usize = self.i;
+        let j: usize = self.j;
         let pTSP = &self.pTSP;
         //
-        let mut diff : f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]] 
-        - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]] 
-        - pTSP.dist[[s[j - 1] as usize, s[j] as usize]] 
-        - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
+        let mut diff: f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]]
+            - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]]
+            - pTSP.dist[[s[j - 1] as usize, s[j] as usize]]
+            - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]])
+            as f64;
         //
-        diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]] 
-        + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]] 
-        + pTSP.dist[[s[j - 1] as usize, s[i] as usize]] 
-        + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
+        diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]]
+            + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]]
+            + pTSP.dist[[s[j - 1] as usize, s[i] as usize]]
+            + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
         // solution swap
         let rev = self.apply(se);
         //
@@ -171,37 +165,36 @@ impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap
     //
 
     //fn cost(const ESolutionTSP& se, bool allowEstimated) -> op<Evaluation<int>>
-    fn cost(&self, se: &ESolutionTSP, _allowEstimated: bool) -> Option<Evaluation> 
-    {
-       assert!(!se.second().isOutdated());
-       let s = &se.first();
-       //
-       let i : usize = self.i;
-       let j : usize = self.j;
-       let pTSP = &self.pTSP;
-       //
-       let mut diff : f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]] 
-       - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]] 
-       - pTSP.dist[[s[j - 1] as usize, s[j] as usize]] 
-       - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
-       //
-       diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]] 
-       + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]] 
-       + pTSP.dist[[s[j - 1] as usize, s[i] as usize]] 
-       + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
-       //
-       return Some(Evaluation{objVal: diff, outdated: false});
+    fn cost(&self, se: &ESolutionTSP, _allowEstimated: bool) -> Option<Evaluation> {
+        assert!(!se.second().isOutdated());
+        let s = &se.first();
+        //
+        let i: usize = self.i;
+        let j: usize = self.j;
+        let pTSP = &self.pTSP;
+        //
+        let mut diff: f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]]
+            - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]]
+            - pTSP.dist[[s[j - 1] as usize, s[j] as usize]]
+            - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]])
+            as f64;
+        //
+        diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]]
+            + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]]
+            + pTSP.dist[[s[j - 1] as usize, s[i] as usize]]
+            + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
+        //
+        return Some(Evaluation {
+            objVal: diff,
+            outdated: false,
+        });
     }
 
-
-    fn toString(&self) -> String
-    {
+    fn toString(&self) -> String {
         let str = format!("MoveSwap i={} j={}", self.i, self.j);
-        return str
+        return str;
     }
 }
-
-
 
 impl fmt::Display for MoveSwap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -214,9 +207,16 @@ impl fmt::Display for MoveSwap {
 // (not necessary, but part of OptFrame Quickstart tutorial)
 // ------------------------
 
-fn makeMoveSwap(pTSP: Rc<TSPProblemContext>, i: usize, j: usize) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>>
-{
-   return Box::new(MoveSwap{pTSP: pTSP.clone(), i, j});
+fn makeMoveSwap(
+    pTSP: Rc<TSPProblemContext>,
+    i: usize,
+    j: usize,
+) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
+    return Box::new(MoveSwap {
+        pTSP: pTSP.clone(),
+        i,
+        j,
+    });
 }
 
 // ------------------------
@@ -249,10 +249,9 @@ fn main() {
     // will not use local variable '_pTSP' (only P_TSP),
     // otherwise 'frandom' becomes closure, not lambda
     // =================================================
-    let pTSP = TSPProblemContext{
-        n:5,
-        dist: Array2::<i32>::ones((5,5))
-        //dist: [[0 as i32; 5].to_vec() ; 5].to_vec()
+    let pTSP = TSPProblemContext {
+        n: 5,
+        dist: Array2::<i32>::ones((5, 5)), //dist: [[0 as i32; 5].to_vec() ; 5].to_vec()
     };
 
     //let mut v1 : Vec<i32> = Vec::new();
@@ -269,18 +268,19 @@ fn main() {
 
     //let fc = FConstructive{func : frandom};
 
-    let fc = FConstructive{func : || -> Vec<i32> {
-            let _n : usize = pTSP.n;
+    let fc = FConstructive {
+        func: || -> Vec<i32> {
+            let _n: usize = pTSP.n;
             //let v : Vec<i32> = Vec::new();
-            let mut v : Vec<i32> = vec![0; _n];
-            let mut i : usize = 0;
+            let mut v: Vec<i32> = vec![0; _n];
+            let mut i: usize = 0;
             while i < _n {
                 v[i] = i as i32;
-                i=i+1;
+                i = i + 1;
             }
             v.shuffle(&mut thread_rng());
-            return v
-        }
+            return v;
+        },
     };
 
     let sol = fc.generateSolution();
@@ -288,36 +288,46 @@ fn main() {
     print!("solution: {:?}\n", sol);
     print!("distances:\n {:?}\n", pTSP.dist);
 
-    let fev = FEvaluator{fEvaluate : |s : &Vec<i32>| -> Evaluation {
-
-        let mut f : f64 = 0.0;
-        let mut i : usize = 0;
-        while i < (pTSP.n - 1) {
-            f += pTSP.dist[[s[i] as usize, s[i + 1] as usize]] as f64;
-            i = i + 1;
-        }
-        f += pTSP.dist[[s[pTSP.n - 1] as usize, s[0] as usize]] as f64;
-        return Evaluation{ objVal: f, outdated: false };
-    }, phantomXS : PhantomData, phantomXEv : PhantomData
+    let fev = FEvaluator {
+        fEvaluate: |s: &Vec<i32>| -> Evaluation {
+            let mut f: f64 = 0.0;
+            let mut i: usize = 0;
+            while i < (pTSP.n - 1) {
+                f += pTSP.dist[[s[i] as usize, s[i + 1] as usize]] as f64;
+                i = i + 1;
+            }
+            f += pTSP.dist[[s[pTSP.n - 1] as usize, s[0] as usize]] as f64;
+            return Evaluation {
+                objVal: f,
+                outdated: false,
+            };
+        },
+        phantomXS: PhantomData,
+        phantomXEv: PhantomData,
     };
 
     let ev = fev.evaluate(&sol);
 
     print!("evaluation: {:?}\n", ev.evaluation());
 
-    // ====================== 
+    // ======================
     // tests with moves
     // ======================
 
-
-
-    let my_pTSP : Rc<TSPProblemContext> = Rc::new(pTSP);
+    let my_pTSP: Rc<TSPProblemContext> = Rc::new(pTSP);
     //
-    let mv1 = MoveSwap{pTSP: my_pTSP, i:0, j:1};
+    let mv1 = MoveSwap {
+        pTSP: my_pTSP,
+        i: 0,
+        j: 1,
+    };
 
     print!("mv1: {}\n", mv1);
 
-    let mut esol = ESolutionTSP{first_value : sol, second_value : ev};
+    let mut esol = ESolutionTSP {
+        first_value: sol,
+        second_value: ev,
+    };
 
     let mv2 = mv1.apply(&mut esol);
 
@@ -327,12 +337,10 @@ fn main() {
 
     //print!("mv2: {}\n", *mv2);
 
-
     //let f2 : dyn Fn()->Vec<i32> = frandom;
 
     // Generate random solution
     //FConstructive<std::vector<int>> crand{
     //frandom
     //};
-
 }

--- a/src/optfcore/fconstructive.rs
+++ b/src/optfcore/fconstructive.rs
@@ -1,21 +1,22 @@
 //mod super::optframe::core::base_concepts;
 //mod super::optframe::core::constructive;
 //
-pub use super::optframe::core::base_concepts::{XSolution, XEvaluation, XESolution};
-pub use super::optframe::core::constructive::{Constructive};
+pub use super::optframe::core::base_concepts::{XESolution, XEvaluation, XSolution};
+pub use super::optframe::core::constructive::Constructive;
 
 pub struct FConstructive<XS: XSolution, F>
- where  F: Fn() -> XS
+where
+    F: Fn() -> XS,
 {
     //pub func : fn()->XS // pointer
-    pub func: F
+    pub func: F,
 }
 
-impl<XS: XSolution, F> Constructive<XS> for FConstructive<XS, F> 
-where  F: Fn() -> XS
+impl<XS: XSolution, F> Constructive<XS> for FConstructive<XS, F>
+where
+    F: Fn() -> XS,
 {
-    fn generateSolution(&self) -> XS
-    {
-        return (self.func)()
+    fn generateSolution(&self) -> XS {
+        return (self.func)();
     }
 }

--- a/src/optfcore/fconstructive.rs
+++ b/src/optfcore/fconstructive.rs
@@ -16,7 +16,7 @@ impl<XS: XSolution, F> Constructive<XS> for FConstructive<XS, F>
 where
     F: Fn() -> XS,
 {
-    fn generateSolution(&self) -> XS {
+    fn generate_solution(&self) -> XS {
         (self.func)()
     }
 }

--- a/src/optfcore/fconstructive.rs
+++ b/src/optfcore/fconstructive.rs
@@ -17,6 +17,6 @@ where
     F: Fn() -> XS,
 {
     fn generateSolution(&self) -> XS {
-        return (self.func)();
+        (self.func)()
     }
 }

--- a/src/optfcore/fevaluator.rs
+++ b/src/optfcore/fevaluator.rs
@@ -27,7 +27,7 @@ where
     F: Fn(&XS) -> XEv,
 {
     fn evaluate(&self, s: &XS) -> XEv {
-        return (self.fEvaluate)(s);
+        (self.fEvaluate)(s)
     }
 }
 

--- a/src/optfcore/fevaluator.rs
+++ b/src/optfcore/fevaluator.rs
@@ -1,6 +1,5 @@
-
-pub use super::optframe::core::base_concepts::{XSolution, XEvaluation, XESolution};
-pub use super::optframe::core::evaluator::{Evaluator};
+pub use super::optframe::core::base_concepts::{XESolution, XEvaluation, XSolution};
+pub use super::optframe::core::evaluator::Evaluator;
 
 use std::marker::PhantomData;
 
@@ -12,8 +11,10 @@ enum MinOrMax
 }
 */
 
-pub struct FEvaluator<XS: XSolution, XEv: XEvaluation, F>//, XES: XESolution<XS, XEv>, F>
- where  F: Fn(&XS) -> XEv
+pub struct FEvaluator<XS: XSolution, XEv: XEvaluation, F>
+//, XES: XESolution<XS, XEv>, F>
+where
+    F: Fn(&XS) -> XEv,
 {
     pub fEvaluate: F,
     pub phantomXS: PhantomData<XS>,
@@ -21,18 +22,18 @@ pub struct FEvaluator<XS: XSolution, XEv: XEvaluation, F>//, XES: XESolution<XS,
     //phantomXES: PhantomData<XES>, // TODO: remove?
 }
 
-impl<XS: XSolution, XEv: XEvaluation, F> Evaluator<XS, XEv>  //Evaluator<XS, XEv, XES> 
-       for FEvaluator<XS, XEv, F> 
-where  F: Fn(&XS) -> XEv
+impl<XS: XSolution, XEv: XEvaluation, F> Evaluator<XS, XEv> for FEvaluator<XS, XEv, F>
+where
+    F: Fn(&XS) -> XEv,
 {
-    fn evaluate(&self, s: &XS) -> XEv
-    {
-        return (self.fEvaluate)(s)
+    fn evaluate(&self, s: &XS) -> XEv {
+        return (self.fEvaluate)(s);
     }
 }
 
-impl<XS: XSolution, XEv: XEvaluation, F> FEvaluator<XS, XEv, F>  //FEvaluator<XS, XEv, XES, F> 
-where  F: Fn(&XS) -> XEv
+impl<XS: XSolution, XEv: XEvaluation, F> FEvaluator<XS, XEv, F>
+//FEvaluator<XS, XEv, XES, F>
+where
+    F: Fn(&XS) -> XEv
 {
-
 }

--- a/src/optfcore/fevaluator.rs
+++ b/src/optfcore/fevaluator.rs
@@ -16,9 +16,9 @@ pub struct FEvaluator<XS: XSolution, XEv: XEvaluation, F>
 where
     F: Fn(&XS) -> XEv,
 {
-    pub fEvaluate: F,
-    pub phantomXS: PhantomData<XS>,
-    pub phantomXEv: PhantomData<XEv>,
+    pub f_evaluate: F,
+    pub phantom_xs: PhantomData<XS>,
+    pub phantom_xev: PhantomData<XEv>,
     //phantomXES: PhantomData<XES>, // TODO: remove?
 }
 
@@ -27,7 +27,7 @@ where
     F: Fn(&XS) -> XEv,
 {
     fn evaluate(&self, s: &XS) -> XEv {
-        (self.fEvaluate)(s)
+        (self.f_evaluate)(s)
     }
 }
 

--- a/src/optframe/core.rs
+++ b/src/optframe/core.rs
@@ -1,4 +1,3 @@
-
 // declare modules that will be available to others...
 pub mod base_concepts;
 pub mod constructive;
@@ -7,5 +6,5 @@ pub mod evaluator;
 pub mod mod_move;
 
 pub use constructive::Constructive;
-pub use evaluator::Evaluator;
 pub use evaluation::Evaluation;
+pub use evaluator::Evaluator;

--- a/src/optframe/core/base_concepts.rs
+++ b/src/optframe/core/base_concepts.rs
@@ -15,10 +15,10 @@ pub trait XSolution {}
 
 pub trait XEvaluation<R: Real = f64> {
     fn evaluation(&self) -> R;
-    fn setObjFunction(&mut self, objVal: R) -> ();
+    fn setObjFunction(&mut self, objVal: R);
     // variable 'outdated'
     fn isOutdated(&self) -> bool;
-    fn setOutdated(&mut self, outdated: bool) -> ();
+    fn setOutdated(&mut self, outdated: bool);
 }
 
 pub trait XESolution<XS: XSolution, XEv: XEvaluation> {

--- a/src/optframe/core/base_concepts.rs
+++ b/src/optframe/core/base_concepts.rs
@@ -15,10 +15,10 @@ pub trait XSolution {}
 
 pub trait XEvaluation<R: Real = f64> {
     fn evaluation(&self) -> R;
-    fn setObjFunction(&mut self, objVal: R);
+    fn set_obj_function(&mut self, obj_val: R);
     // variable 'outdated'
-    fn isOutdated(&self) -> bool;
-    fn setOutdated(&mut self, outdated: bool);
+    fn is_outdated(&self) -> bool;
+    fn set_outdated(&mut self, outdated: bool);
 }
 
 pub trait XESolution<XS: XSolution, XEv: XEvaluation> {

--- a/src/optframe/core/base_concepts.rs
+++ b/src/optframe/core/base_concepts.rs
@@ -8,12 +8,10 @@ use num_traits::real::Real;
 
 //#[derive(Copy, Clone)]
 // TODO: REQUIRES Copy!
-pub trait XRepresentation {
-}
+pub trait XRepresentation {}
 
 // TODO: REQUIRES XRepresentation
-pub trait XSolution {
-}
+pub trait XSolution {}
 
 pub trait XEvaluation<R: Real = f64> {
     fn evaluation(&self) -> R;
@@ -29,4 +27,3 @@ pub trait XESolution<XS: XSolution, XEv: XEvaluation> {
     fn first_mut(&mut self) -> &mut XS;
     fn second_mut(&mut self) -> &mut XEv;
 }
-

--- a/src/optframe/core/constructive.rs
+++ b/src/optframe/core/constructive.rs
@@ -1,9 +1,7 @@
 //mod base_concepts;
 
-#![allow(non_snake_case)]
-
 pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub trait Constructive<XS: XSolution> {
-    fn generateSolution(&self) -> XS;
+    fn generate_solution(&self) -> XS;
 }

--- a/src/optframe/core/constructive.rs
+++ b/src/optframe/core/constructive.rs
@@ -1,9 +1,8 @@
-
 //mod base_concepts;
 
 #![allow(non_snake_case)]
 
-pub use super::base_concepts::{XSolution, XEvaluation, XESolution};
+pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub trait Constructive<XS: XSolution> {
     fn generateSolution(&self) -> XS;

--- a/src/optframe/core/evaluation.rs
+++ b/src/optframe/core/evaluation.rs
@@ -1,28 +1,26 @@
-#![allow(non_snake_case)]
-
 use num_traits::real::Real;
 use std::fmt;
 
 pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub struct Evaluation<R: Real = f64> {
-    pub objVal: R,
+    pub obj_val: R,
     pub outdated: bool,
 }
 
 impl<R: Real> XEvaluation<R> for Evaluation<R> {
     fn evaluation(&self) -> R {
-        self.objVal
+        self.obj_val
     }
-    fn setObjFunction(&mut self, objVal: R) {
-        self.objVal = objVal
+    fn set_obj_function(&mut self, obj_val: R) {
+        self.obj_val = obj_val
     }
     // ======== variable 'outdated' ========
-    fn isOutdated(&self) -> bool {
+    fn is_outdated(&self) -> bool {
         self.outdated
     }
     //
-    fn setOutdated(&mut self, outdated: bool) {
+    fn set_outdated(&mut self, outdated: bool) {
         self.outdated = outdated;
     }
 }

--- a/src/optframe/core/evaluation.rs
+++ b/src/optframe/core/evaluation.rs
@@ -3,30 +3,26 @@
 use num_traits::real::Real;
 use std::fmt;
 
-pub use super::base_concepts::{XSolution, XEvaluation, XESolution};
+pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub struct Evaluation<R: Real = f64> {
     pub objVal: R,
-    pub outdated : bool,
+    pub outdated: bool,
 }
 
 impl<R: Real> XEvaluation<R> for Evaluation<R> {
-    fn evaluation(&self) -> R
-    {
+    fn evaluation(&self) -> R {
         self.objVal
     }
-    fn setObjFunction(&mut self, objVal: R) -> ()
-    {
+    fn setObjFunction(&mut self, objVal: R) -> () {
         self.objVal = objVal
     }
-    // ======== variable 'outdated' ======== 
-    fn isOutdated(&self) -> bool
-    {
+    // ======== variable 'outdated' ========
+    fn isOutdated(&self) -> bool {
         return self.outdated;
     }
     //
-    fn setOutdated(&mut self, outdated: bool) -> ()
-    {
+    fn setOutdated(&mut self, outdated: bool) -> () {
         self.outdated = outdated;
     }
 }

--- a/src/optframe/core/evaluation.rs
+++ b/src/optframe/core/evaluation.rs
@@ -14,15 +14,15 @@ impl<R: Real> XEvaluation<R> for Evaluation<R> {
     fn evaluation(&self) -> R {
         self.objVal
     }
-    fn setObjFunction(&mut self, objVal: R) -> () {
+    fn setObjFunction(&mut self, objVal: R) {
         self.objVal = objVal
     }
     // ======== variable 'outdated' ========
     fn isOutdated(&self) -> bool {
-        return self.outdated;
+        self.outdated
     }
     //
-    fn setOutdated(&mut self, outdated: bool) -> () {
+    fn setOutdated(&mut self, outdated: bool) {
         self.outdated = outdated;
     }
 }

--- a/src/optframe/core/evaluator.rs
+++ b/src/optframe/core/evaluator.rs
@@ -1,10 +1,10 @@
-
 //mod base_concepts;
 
 #![allow(non_snake_case)]
 
-pub use super::base_concepts::{XSolution, XEvaluation, XESolution};
+pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
-pub trait Evaluator<XS: XSolution, XEv: XEvaluation>{//, XES: XESolution<XS, XEv>> {
+pub trait Evaluator<XS: XSolution, XEv: XEvaluation> {
+    //, XES: XESolution<XS, XEv>> {
     fn evaluate(&self, s: &XS) -> XEv;
 }

--- a/src/optframe/core/evaluator.rs
+++ b/src/optframe/core/evaluator.rs
@@ -1,7 +1,5 @@
 //mod base_concepts;
 
-#![allow(non_snake_case)]
-
 pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub trait Evaluator<XS: XSolution, XEv: XEvaluation> {

--- a/src/optframe/core/mod_move.rs
+++ b/src/optframe/core/mod_move.rs
@@ -1,4 +1,3 @@
-
 //mod base_concepts;
 
 // module 'move' is named 'mod_move'
@@ -10,42 +9,42 @@ use std::fmt;
 use std::fmt::Display;
 */
 
-pub use super::base_concepts::{XSolution, XEvaluation, XESolution};
+pub use super::base_concepts::{XESolution, XEvaluation, XSolution};
 
 pub trait Move<XS, XEv, XES: XESolution<XS, XEv>>
-   where XS: XSolution, XEv: XEvaluation
-{//, XES: XESolution<XS, XEv>> {
+where
+    XS: XSolution,
+    XEv: XEvaluation,
+{
+    //, XES: XESolution<XS, XEv>> {
 
     //
     fn apply(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>>;
     //
-    fn canBeApplied(&self, _se: &XES) -> bool
-    {
+    fn canBeApplied(&self, _se: &XES) -> bool {
         // default: all can be applied
-        return true
+        return true;
     }
     //
     fn applyUpdate(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>> {
+        let e: &mut XEv = &mut se.second_mut();
+        // ====== from OptFrame (C++) ======
+        // boolean 'outdated' indicates that Evaluation needs update (after Solution change)
+        // note that even if the reverse move is applied, the Evaluation will continue with
+        // the outdated status set to true. So more efficient approaches may rewrite this
+        // method, or use  efficient re-evaluation by means of the 'cost' method.
+        e.setOutdated(true);
+        // apply the move to R and ADS, saving the reverse (or undo) move
+        let rev = self.apply(se); // Box<dyn Move<XS, XEv, XES>>
+                                  // update neighborhood local optimum status TODO:deprecated
+                                  //updateNeighStatus(se);
 
-      let e : &mut XEv = &mut se.second_mut();
-      // ====== from OptFrame (C++) ====== 
-      // boolean 'outdated' indicates that Evaluation needs update (after Solution change)
-      // note that even if the reverse move is applied, the Evaluation will continue with
-      // the outdated status set to true. So more efficient approaches may rewrite this
-      // method, or use  efficient re-evaluation by means of the 'cost' method.
-      e.setOutdated(true);
-      // apply the move to R and ADS, saving the reverse (or undo) move
-      let rev = self.apply(se); // Box<dyn Move<XS, XEv, XES>>
-      // update neighborhood local optimum status TODO:deprecated
-      //updateNeighStatus(se);
-
-      // return reverse move (or null)
-      return rev;
+        // return reverse move (or null)
+        return rev;
     }
     //
-    fn cost(&self, _se: &XES, _allowEstimated: bool) -> Option<XEv> 
-    {
-       return None;
+    fn cost(&self, _se: &XES, _allowEstimated: bool) -> Option<XEv> {
+        return None;
     }
 
     // ======= from Component =======

--- a/src/optframe/core/mod_move.rs
+++ b/src/optframe/core/mod_move.rs
@@ -23,11 +23,11 @@ where
     //
     fn canBeApplied(&self, _se: &XES) -> bool {
         // default: all can be applied
-        return true;
+        true
     }
     //
     fn applyUpdate(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>> {
-        let e: &mut XEv = &mut se.second_mut();
+        let e: &mut XEv = se.second_mut();
         // ====== from OptFrame (C++) ======
         // boolean 'outdated' indicates that Evaluation needs update (after Solution change)
         // note that even if the reverse move is applied, the Evaluation will continue with
@@ -35,16 +35,16 @@ where
         // method, or use  efficient re-evaluation by means of the 'cost' method.
         e.setOutdated(true);
         // apply the move to R and ADS, saving the reverse (or undo) move
-        let rev = self.apply(se); // Box<dyn Move<XS, XEv, XES>>
-                                  // update neighborhood local optimum status TODO:deprecated
-                                  //updateNeighStatus(se);
+        // Box<dyn Move<XS, XEv, XES>>
+        // update neighborhood local optimum status TODO:deprecated
+        //updateNeighStatus(se);
 
         // return reverse move (or null)
-        return rev;
+        self.apply(se)
     }
     //
     fn cost(&self, _se: &XES, _allowEstimated: bool) -> Option<XEv> {
-        return None;
+        None
     }
 
     // ======= from Component =======

--- a/src/optframe/core/mod_move.rs
+++ b/src/optframe/core/mod_move.rs
@@ -2,8 +2,6 @@
 
 // module 'move' is named 'mod_move'
 
-#![allow(non_snake_case)]
-
 /*
 use std::fmt;
 use std::fmt::Display;
@@ -21,19 +19,19 @@ where
     //
     fn apply(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>>;
     //
-    fn canBeApplied(&self, _se: &XES) -> bool {
+    fn can_be_applied(&self, _se: &XES) -> bool {
         // default: all can be applied
         true
     }
     //
-    fn applyUpdate(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>> {
+    fn apply_update(&self, se: &mut XES) -> Box<dyn Move<XS, XEv, XES>> {
         let e: &mut XEv = se.second_mut();
         // ====== from OptFrame (C++) ======
         // boolean 'outdated' indicates that Evaluation needs update (after Solution change)
         // note that even if the reverse move is applied, the Evaluation will continue with
         // the outdated status set to true. So more efficient approaches may rewrite this
         // method, or use  efficient re-evaluation by means of the 'cost' method.
-        e.setOutdated(true);
+        e.set_outdated(true);
         // apply the move to R and ADS, saving the reverse (or undo) move
         // Box<dyn Move<XS, XEv, XES>>
         // update neighborhood local optimum status TODO:deprecated
@@ -43,12 +41,12 @@ where
         self.apply(se)
     }
     //
-    fn cost(&self, _se: &XES, _allowEstimated: bool) -> Option<XEv> {
+    fn cost(&self, _se: &XES, _allow_estimated: bool) -> Option<XEv> {
         None
     }
 
     // ======= from Component =======
-    fn toString(&self) -> String;
+    fn to_string(&self) -> String;
 }
 
 /*

--- a/src/optframe/heuristics.rs
+++ b/src/optframe/heuristics.rs
@@ -1,1 +1,1 @@
-pub use super::core::constructive::{Constructive};
+pub use super::core::constructive::Constructive;

--- a/src/tsp_test.rs
+++ b/src/tsp_test.rs
@@ -82,7 +82,7 @@ impl fmt::Display for TSPProblemContext {
 // ------------------------
 
 pub struct MoveSwap {
-    pub pTSP: Rc<TSPProblemContext>,
+    pub p_tsp: Rc<TSPProblemContext>,
     pub i: usize,
     pub j: usize,
 }
@@ -101,83 +101,83 @@ impl Move<Vec<i32>, Evaluation, ESolutionTSP> for MoveSwap {
         // reverse move
 
         Box::new(MoveSwap {
-            pTSP: self.pTSP.clone(),
+            p_tsp: self.p_tsp.clone(),
             i: self.j,
             j: self.i,
         })
     }
 
-    fn canBeApplied(&self, _se: &ESolutionTSP) -> bool {
+    fn can_be_applied(&self, _se: &ESolutionTSP) -> bool {
         (i32::abs((self.i - self.j) as i32) >= 2) && (self.i >= 1) && (self.j >= 1)
     }
     //
 
-    fn applyUpdate(
+    fn apply_update(
         &self,
         se: &mut ESolutionTSP,
     ) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
         // input cannot be outdated
-        assert!(!se.second().isOutdated());
+        assert!(!se.second().is_outdated());
         let s = &mut se.first();
         //
         let i: usize = self.i;
         let j: usize = self.j;
-        let pTSP = &self.pTSP;
+        let p_tsp = &self.p_tsp;
         //
-        let mut diff: f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]]
-            - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]]
-            - pTSP.dist[[s[j - 1] as usize, s[j] as usize]]
-            - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]])
+        let mut diff: f64 = (-p_tsp.dist[[s[(i - 1)] as usize, s[i] as usize]]
+            - p_tsp.dist[[s[i] as usize, s[(i + 1) % p_tsp.n] as usize]]
+            - p_tsp.dist[[s[j - 1] as usize, s[j] as usize]]
+            - p_tsp.dist[[s[j] as usize, s[(j + 1) % p_tsp.n] as usize]])
             as f64;
         //
-        diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]]
-            + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]]
-            + pTSP.dist[[s[j - 1] as usize, s[i] as usize]]
-            + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
+        diff += (p_tsp.dist[[s[(i - 1)] as usize, s[j] as usize]]
+            + p_tsp.dist[[s[j] as usize, s[(i + 1) % p_tsp.n] as usize]]
+            + p_tsp.dist[[s[j - 1] as usize, s[i] as usize]]
+            + p_tsp.dist[[s[i] as usize, s[(j + 1) % p_tsp.n] as usize]]) as f64;
         // solution swap
         let rev = self.apply(se);
         //
-        let newObjVal = se.second().evaluation() + diff;
-        se.second_mut().setObjFunction(newObjVal);
+        let new_obj_val = se.second().evaluation() + diff;
+        se.second_mut().set_obj_function(new_obj_val);
         //se.second().setObjFunction(se.second().evaluation() + diff);
         rev
     }
     //
 
     //fn cost(const ESolutionTSP& se, bool allowEstimated) -> op<Evaluation<int>>
-    fn cost(&self, se: &ESolutionTSP, _allowEstimated: bool) -> Option<Evaluation> {
-        assert!(!se.second().isOutdated());
+    fn cost(&self, se: &ESolutionTSP, _allow_estimated: bool) -> Option<Evaluation> {
+        assert!(!se.second().is_outdated());
         let s = &se.first();
         //
         let i: usize = self.i;
         let j: usize = self.j;
-        let pTSP = &self.pTSP;
+        let p_tsp = &self.p_tsp;
         //
-        let mut diff: f64 = (-pTSP.dist[[s[(i - 1)] as usize, s[i] as usize]]
-            - pTSP.dist[[s[i] as usize, s[(i + 1) % pTSP.n] as usize]]
-            - pTSP.dist[[s[j - 1] as usize, s[j] as usize]]
-            - pTSP.dist[[s[j] as usize, s[(j + 1) % pTSP.n] as usize]])
+        let mut diff: f64 = (-p_tsp.dist[[s[(i - 1)] as usize, s[i] as usize]]
+            - p_tsp.dist[[s[i] as usize, s[(i + 1) % p_tsp.n] as usize]]
+            - p_tsp.dist[[s[j - 1] as usize, s[j] as usize]]
+            - p_tsp.dist[[s[j] as usize, s[(j + 1) % p_tsp.n] as usize]])
             as f64;
         //
-        diff += (pTSP.dist[[s[(i - 1)] as usize, s[j] as usize]]
-            + pTSP.dist[[s[j] as usize, s[(i + 1) % pTSP.n] as usize]]
-            + pTSP.dist[[s[j - 1] as usize, s[i] as usize]]
-            + pTSP.dist[[s[i] as usize, s[(j + 1) % pTSP.n] as usize]]) as f64;
+        diff += (p_tsp.dist[[s[(i - 1)] as usize, s[j] as usize]]
+            + p_tsp.dist[[s[j] as usize, s[(i + 1) % p_tsp.n] as usize]]
+            + p_tsp.dist[[s[j - 1] as usize, s[i] as usize]]
+            + p_tsp.dist[[s[i] as usize, s[(j + 1) % p_tsp.n] as usize]]) as f64;
         //
         Some(Evaluation {
-            objVal: diff,
+            obj_val: diff,
             outdated: false,
         })
     }
 
-    fn toString(&self) -> String {
+    fn to_string(&self) -> String {
         format!("MoveSwap i={} j={}", self.i, self.j)
     }
 }
 
 impl fmt::Display for MoveSwap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.toString())
+        write!(f, "{}", <Self as Move<_, _, _>>::to_string(self))
     }
 }
 
@@ -187,12 +187,12 @@ impl fmt::Display for MoveSwap {
 // ------------------------
 
 #[allow(dead_code)]
-fn makeMoveSwap(
-    pTSP: Rc<TSPProblemContext>,
+fn make_move_swap(
+    p_tsp: Rc<TSPProblemContext>,
     i: usize,
     j: usize,
 ) -> Box<dyn Move<Vec<i32>, Evaluation, ESolutionTSP>> {
-    Box::new(MoveSwap { pTSP, i, j })
+    Box::new(MoveSwap { p_tsp, i, j })
 }
 
 // ------------------------
@@ -225,7 +225,7 @@ fn main() {
     // will not use local variable '_pTSP' (only P_TSP),
     // otherwise 'frandom' becomes closure, not lambda
     // =================================================
-    let pTSP = TSPProblemContext {
+    let p_tsp = TSPProblemContext {
         n: 5,
         dist: Array2::<i32>::ones((5, 5)), //dist: [[0 as i32; 5].to_vec() ; 5].to_vec()
     };
@@ -246,7 +246,7 @@ fn main() {
 
     let fc = FConstructive {
         func: || -> Vec<i32> {
-            let _n: usize = pTSP.n;
+            let _n: usize = p_tsp.n;
             //let v : Vec<i32> = Vec::new();
             let mut v: Vec<i32> = vec![0; _n];
             let mut i: usize = 0;
@@ -259,27 +259,27 @@ fn main() {
         },
     };
 
-    let sol = fc.generateSolution();
+    let sol = fc.generate_solution();
 
     println!("solution: {:?}", sol);
-    println!("distances:\n {:?}", pTSP.dist);
+    println!("distances:\n {:?}", p_tsp.dist);
 
     let fev = FEvaluator {
-        fEvaluate: |s: &Vec<i32>| -> Evaluation {
+        f_evaluate: |s: &Vec<i32>| -> Evaluation {
             let mut f: f64 = 0.0;
             let mut i: usize = 0;
-            while i < (pTSP.n - 1) {
-                f += pTSP.dist[[s[i] as usize, s[i + 1] as usize]] as f64;
+            while i < (p_tsp.n - 1) {
+                f += p_tsp.dist[[s[i] as usize, s[i + 1] as usize]] as f64;
                 i += 1;
             }
-            f += pTSP.dist[[s[pTSP.n - 1] as usize, s[0] as usize]] as f64;
+            f += p_tsp.dist[[s[p_tsp.n - 1] as usize, s[0] as usize]] as f64;
             Evaluation {
-                objVal: f,
+                obj_val: f,
                 outdated: false,
             }
         },
-        phantomXS: PhantomData,
-        phantomXEv: PhantomData,
+        phantom_xs: PhantomData,
+        phantom_xev: PhantomData,
     };
 
     let ev = fev.evaluate(&sol);
@@ -290,10 +290,10 @@ fn main() {
     // tests with moves
     // ======================
 
-    let my_pTSP: Rc<TSPProblemContext> = Rc::new(pTSP);
+    let my_p_tsp: Rc<TSPProblemContext> = Rc::new(p_tsp);
     //
     let mv1 = MoveSwap {
-        pTSP: my_pTSP,
+        p_tsp: my_p_tsp,
         i: 0,
         j: 1,
     };
@@ -307,7 +307,7 @@ fn main() {
 
     let mv2 = mv1.apply(&mut esol);
 
-    println!("mv2: {}", mv2.toString());
+    println!("mv2: {}", mv2.to_string());
 
     let _mv3 = mv2.apply(&mut esol);
 


### PR DESCRIPTION
- style: run `cargo fmt`
  - people always use rustfmt to determine how the code will look like.
- refactor: convert project from bin to lib
- fix: use unambiguous name for optframe module
- refactor: apply clippy suggestions
  - clippy is a linter from the rust project which helps following good style.
- docs: include README on crate documentation
- refactor: remove `#[allow(non_snake_case)]`
  - Rust libs always follow the casing determined by the language. You'll get used to it.